### PR TITLE
Removed deprecated non-pub docroot support. Is cleaner like this.

### DIFF
--- a/varnish6-xkey.vcl
+++ b/varnish6-xkey.vcl
@@ -101,7 +101,7 @@ sub vcl_recv {
     }
 
     # Bypass health check requests
-    if (req.url ~ "^/(pub/)?(health_check.php)$") {
+    if (req.url == "health_check.php") {
         return (pass);
     }
 
@@ -115,7 +115,7 @@ sub vcl_recv {
     }
 
     # Static files caching
-    if (req.url ~ "^/(pub/)?(media|static)/") {
+    if (req.url ~ "^/(media|static)/") {
         # Static files should not be cached by default
         return (pass);
 
@@ -221,7 +221,7 @@ sub vcl_deliver {
     }
 
     # Let browser and Cloudflare cache non-static content that are cacheable for short period of time
-    if (resp.http.Cache-Control !~ "private" && req.url !~ "^/(pub/)?(media|static)/" && obj.ttl > 0s) {
+    if (resp.http.Cache-Control !~ "private" && req.url !~ "^/(media|static)/" && obj.ttl > 0s) {
         set resp.http.Cache-Control = "must-revalidate, max-age=60";
     }
 


### PR DESCRIPTION
Since we don't have `/pub/` anymore in [the re-added health-check probe](https://github.com/elgentos/varnish-task-force/pull/53), it kind of make sense to remove this support everywhere.