### PR TITLE
#22 Replaced the previous ban logic with a softpurge for full cache inval…

### DIFF
--- a/varnish6-xkey.vcl
+++ b/varnish6-xkey.vcl
@@ -66,7 +66,8 @@ sub vcl_recv {
 
         # Full Page Cache flush
         if (req.http.X-Magento-Tags-Pattern == ".*") {
-            ban("obj.http.X-Magento-Tags ~ " + req.http.X-Magento-Tags-Pattern);
+            set req.http.n-gone = xkey.softpurge("all");
+            return (synth(200, "Invalidated " + req.http.n-gone + " objects (full flush)"));
         } elseif (req.http.X-Magento-Tags-Pattern) {
             # replace "((^|,)cat_c(,|$))|((^|,)cat_p(,|$))" to be "cat_c,cat_p"
             set req.http.X-Magento-Tags-Pattern = regsuball(req.http.X-Magento-Tags-Pattern, "[^a-zA-Z0-9_-]+" ,",");


### PR DESCRIPTION
vcl_recv: Implement full page cache flush using xkey softpurge

Replaced the previous ban logic with a softpurge for full cache invalidation, returning a response indicating the number of objects invalidated.